### PR TITLE
View is now removed from it's superview when the tour ends or is skipped

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -255,6 +255,10 @@
     
     if (page == (pageViews.count - 1) && self.swipeToExit) {
         self.alpha = ((self.scrollView.frame.size.width*pageViews.count)-self.scrollView.contentOffset.x)/self.scrollView.frame.size.width;
+		
+		if (self.alpha < 0.1f) {
+			[self removeFromSuperview];
+		}
     } else {
         [self crossDissolveForOffset:offset];
     }
@@ -378,7 +382,9 @@
 - (void)hideWithFadeOutDuration:(CGFloat)duration {
     [UIView animateWithDuration:duration animations:^{
         self.alpha = 0;
-    } completion:nil];
+    } completion:^(BOOL finished){
+		[self removeFromSuperview];
+	}];
 }
 
 - (void)showInView:(UIView *)view animateDuration:(CGFloat)duration {


### PR DESCRIPTION
I found that the Intro View was not correctly removing itself from it's superview once the tour had finished, it's alpha was simply being set to 0. This creates undesired effects, one of the biggest ones being that scroll views contained inside a navigation controller would no longer respond to 'scrollsToTop' (as there is technically more than one UIScrollView present in the view hierarchy).

I've ensured it removes itself from the superview when the tour is skipped, or when the alpha becomes low enough as a result of the user scrolling the last page to the end to dismiss the tour.
