### PR TITLE
View is removed from superview upon completion of tour

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -238,9 +238,7 @@
     self.currentPageIndex = scrollView.contentOffset.x/self.scrollView.frame.size.width;
     
     if (self.currentPageIndex == (pageViews.count)) {
-        if ([(id)self.delegate respondsToSelector:@selector(introDidFinish)]) {
-            [self.delegate introDidFinish];
-        }
+        [self finishIntroductionAndRemoveSelf];
     } else {
         LastPageIndex = self.pageControl.currentPage;
         self.pageControl.currentPage = self.currentPageIndex;
@@ -255,10 +253,6 @@
     
     if (page == (pageViews.count - 1) && self.swipeToExit) {
         self.alpha = ((self.scrollView.frame.size.width*pageViews.count)-self.scrollView.contentOffset.x)/self.scrollView.frame.size.width;
-		
-		if (self.alpha < 0.1f) {
-			[self removeFromSuperview];
-		}
     } else {
         [self crossDissolveForOffset:offset];
     }
@@ -372,10 +366,6 @@
 }
 
 - (void)skipIntroduction {
-    if ([(id)self.delegate respondsToSelector:@selector(introDidFinish)]) {
-        [self.delegate introDidFinish];
-    }
-    
     [self hideWithFadeOutDuration:0.3];
 }
 
@@ -383,7 +373,7 @@
     [UIView animateWithDuration:duration animations:^{
         self.alpha = 0;
     } completion:^(BOOL finished){
-		[self removeFromSuperview];
+		[self finishIntroductionAndRemoveSelf];
 	}];
 }
 
@@ -395,6 +385,14 @@
     [UIView animateWithDuration:duration animations:^{
         self.alpha = 1;
     }];
+}
+
+- (void)finishIntroductionAndRemoveSelf {
+	if ([(id)self.delegate respondsToSelector:@selector(introDidFinish)]) {
+		[self.delegate introDidFinish];
+	}
+	
+	[self removeFromSuperview];
 }
 
 @end


### PR DESCRIPTION
Here we go. Revised code from the previous pull request.

I took some of your suggestions, and instead of worrying about the alpha being below a certain threshold, I've implemented  `-(void)finishIntroductionAndRemoveSelf`, which calls the correct delegate method and removes the view from it's superview. This method is also called in the completion of the `hideWithFadeOutDuration:` method.

I wasn't sure how to remove the previous commit, but the latest commit of mine will overwrite the changes made in there anyway.
