### PR TITLE
Add bgImage page transition with easeOut to prevent the EAIntroView back...

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -21,6 +21,10 @@
 // pageControl Y position - from bottom of the screen
 @property (nonatomic, assign) bool swipeToExit;
 @property (nonatomic, assign) bool hideOffscreenPages;
+
+//Wait longer for opacity change of page background images
+// to prevent the UIView background from appearing
+@property (nonatomic, assign) bool easeOutCrossDisolves;
 @property (nonatomic, retain) UIImage *bgImage;
 @property (nonatomic, retain) UIView *titleView;
 @property (nonatomic, assign) CGFloat titleViewY;

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -258,6 +258,12 @@
     }
 }
 
+
+float easeOutValue(float value) {
+    float inverse = value - 1.0;
+    return 1.0 + inverse * inverse * inverse;
+}
+
 - (void)crossDissolveForOffset:(float)offset {
     NSInteger page = (int)(offset);
     float alphaValue = offset - (int)offset;
@@ -275,6 +281,11 @@
     
     float backLayerAlpha = alphaValue;
     float frontLayerAlpha = (1 - alphaValue);
+    
+    if (self.easeOutCrossDisolves) {
+        backLayerAlpha = easeOutValue(backLayerAlpha);
+        frontLayerAlpha = easeOutValue(frontLayerAlpha);
+    }
     
     [self.pageBgBack setAlpha:backLayerAlpha];
     [self.pageBgFront setAlpha:frontLayerAlpha];


### PR DESCRIPTION
...ground from being shown in full screen page backgrounds.

I was different full background for the page bgImage and found that the background of the EAIntroView was being shown around the middle of a transition between pages. In order to prevent, the ability to use an ease out transition function rather than a linear one prevents this.
