### PR TITLE
Changed UIScrollView to allocate with bounds.

### DIFF
--- a/EAIntroView/EAIntroPage.h
+++ b/EAIntroView/EAIntroPage.h
@@ -28,6 +28,7 @@
 @property (nonatomic, strong) NSString *desc;
 @property (nonatomic, strong) UIFont *descFont;
 @property (nonatomic, strong) UIColor *descColor;
+@property (nonatomic) CGFloat descWidth;
 @property (nonatomic, assign) CGFloat descPositionY;
 @property (nonatomic, strong) NSArray *subviews;
 

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -259,7 +259,15 @@
     }
     
     if([page.desc length]) {
-        CGRect descLabelFrame = CGRectMake(0, self.frame.size.height - page.descPositionY, self.scrollView.frame.size.width, 500);
+        CGRect descLabelFrame; 
+        
+        if(page.descWidth != 0){
+            
+            descLabelFrame = CGRectMake((self.frame.size.width - page.descWidth)/2, self.frame.size.height - page.descPositionY, page.descWidth, 500);
+        }else{
+            descLabelFrame = CGRectMake(0, self.frame.size.height - page.descPositionY, self.scrollView.frame.size.width, 500);
+            
+        }
         
         UITextView *descLabel = [[UITextView alloc] initWithFrame:descLabelFrame];
         descLabel.text = page.desc;
@@ -270,6 +278,7 @@
         descLabel.textAlignment = NSTextAlignmentCenter;
         descLabel.userInteractionEnabled = NO;
         //[descLabel sizeToFit];
+        
         [pageView addSubview:descLabel];
     }
     


### PR DESCRIPTION
Under certain cases where you set Y offset to the frame of `EAIntroView`, this value is copied to the internal scrollview, creating unnecessary padding. This is fixed by allocating the internal `UIScrollView` from bounds instead of frame, which makes sense.
