### PR TITLE
use 'weak' is safer than 'assign'

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -18,7 +18,7 @@
 
 @interface EAIntroView : UIView <UIScrollViewDelegate>
 
-@property (nonatomic, assign) id<EAIntroDelegate> delegate;
+@property (nonatomic, weak) id<EAIntroDelegate> delegate;
 
 // titleView Y position - from top of the screen
 // pageControl Y position - from bottom of the screen


### PR DESCRIPTION
Hi , I am a programmer using EAintroView in my project.
EAintroView is  a beautiful project.

But  i think delegate use weak in @property declarations is better than assign.  It's more safe.

My English not good, but i try let you know what i mean.
Best wishes.
