### PR TITLE
fix crash bug after scroll to end

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -107,6 +107,11 @@
     _currentPageIndex = newPageIndex;
     
     if (self.currentPageIndex == (_pages.count)) {
+        
+        //if run here, it means you cann't  call _pages[self.currentPageIndex],
+        //to be safe, set to the biggest index
+        self.currentPageIndex = _pages.count - 1;
+        
         [self finishIntroductionAndRemoveSelf];
     }
 }


### PR DESCRIPTION
When I swiped the last page to finish the introView, it always crashed.This request will fix this bug.
I think this fix is not the same as https://github.com/ealeksandrov/EAIntroView/issues/42, although they both crashed after swiping.
