### PR TITLE
fixes the flickering of the last view when calling removeFromSuperview. ...

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -120,6 +120,7 @@
 	if ([(id)self.delegate respondsToSelector:@selector(introDidFinish:)]) {
 		[self.delegate introDidFinish:self];
 	}
+    self.alpha = 0;
 	//Calling removeFromSuperview from scrollViewDidEndDecelerating: method leads to crash on iOS versions < 7.0.
     //removeFromSuperview should be called after a delay
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)0);


### PR DESCRIPTION
...To test put a breakpoint on the 128th line of EAIntroView.m and check the view’s opacity when stopped.
