### PR TITLE
Fixed issue where intro:pageAppeared:withIndex: delegate method wasn't being called with tapToNext enabled.

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -653,8 +653,6 @@ float easeOutValue(float value) {
         return;
     }
     
-    _currentPageIndex = currentPageIndex;
-    
     float offset = currentPageIndex * self.scrollView.frame.size.width;
     CGRect pageRect = { .origin.x = offset, .origin.y = 0.0, .size.width = self.scrollView.frame.size.width, .size.height = self.scrollView.frame.size.height };
     [self.scrollView scrollRectToVisible:pageRect animated:animated];


### PR DESCRIPTION
The _currentPageIndex was being set in setCurrentPageIndex:animated so by the time checkIndexForScrollView: was called after the scroll in scrollViewDidEndScrollingAnimation:, notifyDelegateWIthPreviousPage:andCurrentPage had no side effect because the previousPage and currentPage indexes were equal at that point.

Signed-off-by: Jared Allen jared@redcact.us
