### PR TITLE
Replace "descPositionY" with "descPositionOffsetFromCenter"

### DIFF
--- a/EAIntroView/EAIntroPage.h
+++ b/EAIntroView/EAIntroPage.h
@@ -38,7 +38,7 @@ typedef void (^VoidBlock)();
 @property (nonatomic, strong) UIFont *descFont;
 @property (nonatomic, strong) UIColor *descColor;
 @property (nonatomic, assign) CGFloat descWidth;
-@property (nonatomic, assign) CGFloat descPositionY;
+@property (nonatomic, assign) CGFloat descPositionOffetFromCenter;
 
 @property (nonatomic, strong) NSArray *subviews;
 

--- a/EAIntroView/EAIntroPage.m
+++ b/EAIntroView/EAIntroPage.m
@@ -11,7 +11,7 @@
 #define DEFAULT_DESCRIPTION_FONT [UIFont fontWithName:@"HelveticaNeue-Light" size:13.0]
 #define DEFAULT_TITLE_IMAGE_Y_POSITION 50.0f
 #define DEFAULT_TITLE_LABEL_Y_POSITION 160.0f
-#define DEFAULT_DESCRIPTION_LABEL_Y_POSITION 140.0f
+#define DEFAULT_DESCRIPTION_LABEL_OFFSET_FROM_CENTER 0.0f
 
 @interface EAIntroPage ()
 @property(nonatomic, strong, readwrite) UIView *pageView;
@@ -25,7 +25,7 @@
     if (self = [super init]) {
         _titleIconPositionY = DEFAULT_TITLE_IMAGE_Y_POSITION;
         _titlePositionY  = DEFAULT_TITLE_LABEL_Y_POSITION;
-        _descPositionY   = DEFAULT_DESCRIPTION_LABEL_Y_POSITION;
+        _descPositionOffetFromCenter = DEFAULT_DESCRIPTION_LABEL_OFFSET_FROM_CENTER;
         _title = @"";
         _titleFont = DEFAULT_TITLE_FONT;
         _titleColor = DEFAULT_LABEL_COLOR;

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -288,9 +288,9 @@
         CGRect descLabelFrame;
         
         if(page.descWidth != 0) {
-            descLabelFrame = CGRectMake((self.frame.size.width - page.descWidth)/2, self.frame.size.height - page.descPositionY, page.descWidth, 500);
+            descLabelFrame = CGRectMake((self.frame.size.width - page.descWidth)/2, (self.frame.size.height/2) + page.descPositionOffetFromCenter, page.descWidth, 500);
         } else {
-            descLabelFrame = CGRectMake(0, self.frame.size.height - page.descPositionY, self.scrollView.frame.size.width, 500);
+            descLabelFrame = CGRectMake(0, (self.frame.size.height/2) + page.descPositionOffetFromCenter, self.scrollView.frame.size.width, 500);
         }
         
         UITextView *descLabel = [[UITextView alloc] initWithFrame:descLabelFrame];


### PR DESCRIPTION
I've replaced the "descPositionY" property with "descPositionOffsetFromCenter" as it's more ideal in setting the correct position taking into account the newer iPhone 6 and 6 Plus screens.
