### PR TITLE
Set pageControl userInteractionEnabled to no

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -64,6 +64,7 @@
     self.bgViewContentMode = UIViewContentModeScaleAspectFill;
     self.motionEffectsRelativeValue = 40.f;
     self.backgroundColor = [UIColor blackColor];
+    self.pageControl.userInteractionEnabled = NO;
     _scrollingEnabled = YES;
     _titleViewY = 20.f;
     _pageControlY = 50.f;


### PR DESCRIPTION
Had issues swiping through walkthrough pages when swipe was happening over the pageControl. Sometimes swiping from right to left would cause reverse action to occur; the previous page would slide back in from left to right. Setting the pageControl userInteractionEnabled to no fixed this issue.