### PR TITLE
Default background color

### DIFF
--- a/EAIntroView/EAIntroPage.m
+++ b/EAIntroView/EAIntroPage.m
@@ -47,6 +47,7 @@
 + (instancetype)pageWithCustomView:(UIView *)customV {
     EAIntroPage *newPage = [[self alloc] init];
     newPage.customView = customV;
+    newPage.bgColor = customV.backgroundColor;
     return newPage;
 }
 
@@ -58,6 +59,7 @@
     EAIntroPage *newPage = [[self alloc] init];
     newPage.customView = [[aBundle loadNibNamed:nibName owner:newPage options:nil] firstObject];
     [newPage.customView setTranslatesAutoresizingMaskIntoConstraints:NO];
+    newPage.bgColor = newPage.customView.backgroundColor;
     return newPage;
 }
 


### PR DESCRIPTION
Default background color of custom page with customView is background color of customView

It's confusing when your custom view from XIB file becomes transparent on black background of EAIntroView if you didn't set bgColor of each EAIntroPage manually.