### PR TITLE
Exposed buildScrollView-method to allow to manually rebuild intro whe…

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -77,6 +77,7 @@ typedef NS_ENUM(NSUInteger, EAViewAlignment) {
 - (void)showInView:(UIView *)view animateDuration:(CGFloat)duration withInitialPageIndex:(NSUInteger)initialPageIndex;
 
 - (void)hideWithFadeOutDuration:(CGFloat)duration;
+- (void)buildScrollView;
 
 - (void)setCurrentPageIndex:(NSUInteger)currentPageIndex;
 - (void)setCurrentPageIndex:(NSUInteger)currentPageIndex animated:(BOOL)animated;


### PR DESCRIPTION
I exposed buildScrollView, because I needed to rebuild the intro view when the device was rotated or when split screen was used in iPad Air 2 and the view dimensions changed.

I know, this is sort of a dirty quick fix..