### PR TITLE
Exposed + (instancetype)pageWithCustomViewFromNibNamed:(NSString *)ni…

### DIFF
--- a/EAIntroView/EAIntroPage.h
+++ b/EAIntroView/EAIntroPage.h
@@ -60,5 +60,6 @@ typedef void (^VoidBlock)();
 + (instancetype)page;
 + (instancetype)pageWithCustomView:(UIView *)customV;
 + (instancetype)pageWithCustomViewFromNibNamed:(NSString *)nibName;
++ (instancetype)pageWithCustomViewFromNibNamed:(NSString *)nibName bundle:(NSBundle*)aBundle;
 
 @end


### PR DESCRIPTION
…bName bundle:(NSBundle*)aBundle;

It's useful when EAIntroView is used as a dependency of another pod. Then, the main bundle isn't valid.