### PR TITLE
Better accessibility of EAIntroView

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -358,6 +358,14 @@
     tapToNextButton.frame = pageView.bounds;
     tapToNextButton.translatesAutoresizingMaskIntoConstraints = NO;
     [tapToNextButton addTarget:self action:@selector(goToNext:) forControlEvents:UIControlEventTouchUpInside];
+
+    NSString *accessibilityLabel = [self accessibilityLabelForPage:page];
+    if (accessibilityLabel.length > 0) {
+        tapToNextButton.isAccessibilityElement = YES;
+        tapToNextButton.accessibilityLabel = accessibilityLabel;
+        tapToNextButton.accessibilityTraits = UIAccessibilityTraitButton;
+    }
+    
     [pageView addSubview:tapToNextButton];
     
     NSMutableArray *constraints = @[].mutableCopy;
@@ -389,6 +397,7 @@
         titleLabel.numberOfLines = 0;
         titleLabel.tag = kTitleLabelTag;
         titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        titleLabel.isAccessibilityElement = NO;
         
         [pageView addSubview:titleLabel];
         NSLayoutConstraint *weakConstraint = [NSLayoutConstraint constraintWithItem:pageView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:titleLabel attribute:NSLayoutAttributeTop multiplier:1.0 constant:page.titlePositionY];
@@ -409,6 +418,7 @@
         descLabel.userInteractionEnabled = NO;
         descLabel.tag = kDescLabelTag;
         descLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        descLabel.isAccessibilityElement = NO;
         
         [pageView addSubview:descLabel];
         NSLayoutConstraint *weakConstraint = [NSLayoutConstraint constraintWithItem:pageView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:descLabel attribute:NSLayoutAttributeTop multiplier:1.0 constant:page.descPositionY];
@@ -433,6 +443,23 @@
     pageView.alpha = page.alpha;
     
     return pageView;
+}
+
+- (NSString*)accessibilityLabelForPage:(EAIntroPage*)page
+{
+    NSString *accessibilityLabel = nil;
+    if (page.title) {
+        if (page.desc) {
+            accessibilityLabel = [NSString stringWithFormat:@"%@, %@", page.title, page.desc];
+        }
+        else {
+            accessibilityLabel = page.title;
+        }
+    }
+    else {
+        accessibilityLabel = page.desc;
+    }
+    return accessibilityLabel;
 }
 
 - (void)appendCloseViewAtXIndex:(CGFloat*)xIndex {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-target 'EAIntroView', :exclusive => true do
+target 'EAIntroView' do
   pod 'EAIntroView', :path => '../'
   pod 'SMPageControl', '~> 1.2'
 end


### PR DESCRIPTION
Previously, each page view within EAIntroView had various accessible items (e.g. title, desc), that means we had to navigate within a page with VoiceOver and then between each page. That made the understanding how to use the intro view difficult. In addition, each page had a button covering the complete page, which had no proper usability labelling.

I did the following accessibility improvements:
- I made the description and title not accessible
- At their place, I put a meaningful accessibility label on the page wide button (using the title and description).

Now it is easy to navigate between the pages with VoiceOver.