### PR TITLE
Remove global state from EAIntroView's constructor

### DIFF
--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -80,13 +80,6 @@
     self.pages = [pagesArray copy];
     
     [self buildFooterView];
-    
-    // Add observer for device orientation:
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(deviceOrientationDidChange:)
-                                                 name:UIDeviceOrientationDidChangeNotification
-                                               object:nil];
 }
 
 - (void)applyDefaultsToBackgroundImageView:(UIImageView *)backgroundImageView {
@@ -168,10 +161,6 @@
 }
 
 - (void)finishIntroductionAndRemoveSelf {
-	// Remove observer for rotation
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-    
     //prevent last page flicker on disappearing
     self.alpha = 0;
     
@@ -202,6 +191,22 @@
         if ([(id)self.delegate respondsToSelector:@selector(intro:pageAppeared:withIndex:)]) {
             [self.delegate intro:self pageAppeared:_pages[currentPageIndex] withIndex:currentPageIndex];
         }
+    }
+}
+
+-(void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
+    if (self.superview == nil && newSuperview != nil) {
+        // Add observer for device orientation:
+        [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(deviceOrientationDidChange:)
+                                                     name:UIDeviceOrientationDidChangeNotification
+                                                   object:nil];
+    } else if (self.superview != nil && newSuperview == nil) {
+        // Remove observer for rotation
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+        [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
     }
 }
 


### PR DESCRIPTION
The code that modifies global state has been moved into the willMoveIntoSuperView: method.
This fixes a crash on iOS <= 8.
It also fixes an issue where the device would generate Device Orientation Notifications when it shouldn't.

Previously, if an EAIntroView was removed by removing its parent view (or ViewContrroller) - the cleanup code for the EAIntroView wasn't being called.
The same issue existed for an EAIntroView that was created, but not added to a view hierarchy.

Fixes #168