### PR TITLE
Fix for Issue #174 - pageAppeared Delegate Callback

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -83,4 +83,7 @@ typedef NS_ENUM(NSUInteger, EAViewAlignment) {
 - (void)setCurrentPageIndex:(NSUInteger)currentPageIndex;
 - (void)setCurrentPageIndex:(NSUInteger)currentPageIndex animated:(BOOL)animated;
 
+
+- (void)scrollToPageForIndex:(NSUInteger)newPageIndex animated:(BOOL)animated;
+
 @end

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -1007,7 +1007,17 @@ CGFloat easeOutValue(CGFloat value) {
     
     _currentPageIndex = currentPageIndex;
     
-    CGFloat offset = currentPageIndex * self.scrollView.frame.size.width;
+    [self scrollToPageForIndex:currentPageIndex animated:animated];
+}
+
+- (void)scrollToPageForIndex:(NSUInteger)newPageIndex animated:(BOOL)animated
+{
+    if(![self pageForIndex:newPageIndex]) {
+        NSLog(@"Wrong newPageIndex received: %ld",(long)newPageIndex);
+        return;
+    }
+
+    CGFloat offset = newPageIndex * self.scrollView.frame.size.width;
     CGRect pageRect = { .origin.x = offset, .origin.y = 0.0, .size.width = self.scrollView.frame.size.width, .size.height = self.scrollView.frame.size.height };
     [self.scrollView scrollRectToVisible:pageRect animated:animated];
     
@@ -1023,7 +1033,9 @@ CGFloat easeOutValue(CGFloat value) {
     if(self.currentPageIndex + 1 >= [self.pages count]) {
         [self hideWithFadeOutDuration:0.3];
     } else {
-        [self setCurrentPageIndex:self.currentPageIndex + 1 animated:YES];
+        // Just scroll to the new page.
+        // After scrolling ends, we call -checkIndexForScrollView:, which itself sets the new currentPageIndex.
+        [self scrollToPageForIndex:self.currentPageIndex + 1 animated:YES];
     }
 }
 


### PR DESCRIPTION
https://github.com/ealeksandrov/EAIntroView/issues/174

There is a bug in which tapping a page to advance does not call the delegate callback `pageAppeared`. This is because the tap IBAction sets the new `_currentPageIndex` before the `notifyDelegateWithPreviousPage` gets called. This latter method has a check which fails when the currentPageIndex is updated before calling it.

This PR resolves this bug by just making the tap IBAction scroll to the page index and _not_ update the currentPageIndex. Then in the scrollDidEnd callback, we update new currentPageIndex already.

Note that in https://github.com/ealeksandrov/EAIntroView/issues/174 , this bug still exists when one calls the `setCurrentPageIndex:` method. My recommendation is to not expose the `setCurrentPageIndex:` setter, and instead expose the `scrollToPageForIndex:` method. Then, we only ever update the new `currentPageIndex` property once, _after_ the scrollView delegate callback is called.
