### PR TITLE
Adds introWillFinish Delegate Method

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSUInteger, EAViewAlignment) {
 
 @protocol EAIntroDelegate<NSObject>
 @optional
+- (void)introWillFinish:(EAIntroView *)introView wasSkipped:(BOOL)wasSkipped;
 - (void)introDidFinish:(EAIntroView *)introView wasSkipped:(BOOL)wasSkipped;
 - (void)intro:(EAIntroView *)introView pageAppeared:(EAIntroPage *)page withIndex:(NSUInteger)pageIndex;
 - (void)intro:(EAIntroView *)introView pageStartScrolling:(EAIntroPage *)page withIndex:(NSUInteger)pageIndex;

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -155,7 +155,11 @@
         //if run here, it means you can't  call _pages[self.currentPageIndex],
         //to be safe, set to the biggest index
         _currentPageIndex = _pages.count - 1;
-        
+
+        if ([self.delegate respondsToSelector:@selector(introWillFinish:wasSkipped:)]) {
+            [self.delegate introWillFinish:self wasSkipped:self.skipped];
+        }
+
         [self finishIntroductionAndRemoveSelf];
     }
 }
@@ -988,6 +992,10 @@ CGFloat easeOutValue(CGFloat value) {
 }
 
 - (void)hideWithFadeOutDuration:(CGFloat)duration {
+    if ([self.delegate respondsToSelector:@selector(introWillFinish:wasSkipped:)]) {
+        [self.delegate introWillFinish:self wasSkipped:self.skipped];
+    }
+
     [UIView animateWithDuration:duration animations:^{
         self.alpha = 0;
     } completion:^(BOOL finished){


### PR DESCRIPTION
This PR simply introduces a new delegate method: `introWillFinish:wasSkipped:`. I'm using this to begin animating out static views which are atop the IntroView, prior to IntroView's internal 0.3s fade-out.
