### PR TITLE
Adds new delegate method: intro:didScrollWithOffset:

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -29,6 +29,11 @@ typedef NS_ENUM(NSUInteger, EAViewAlignment) {
 - (void)intro:(EAIntroView *)introView pageAppeared:(EAIntroPage *)page withIndex:(NSUInteger)pageIndex;
 - (void)intro:(EAIntroView *)introView pageStartScrolling:(EAIntroPage *)page withIndex:(NSUInteger)pageIndex;
 - (void)intro:(EAIntroView *)introView pageEndScrolling:(EAIntroPage *)page withIndex:(NSUInteger)pageIndex;
+
+// Called for every incremental scroll event.
+// Parameter offset is some fraction of the currentPageIndex, between currentPageIndex-1 and currentPageIndex+1
+// For example, scrolling left and right from page 2 will values in the range [1..3], exclusive
+- (void)intro:(EAIntroView *)introView didScrollWithOffset:(CGFloat)offset;
 @end
 
 @interface EAIntroView : UIView <UIScrollViewDelegate>

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -595,6 +595,10 @@
         
         [self makePanelVisibleAtIndex:self.visiblePageIndex];
     }
+    
+    if ([self.delegate respondsToSelector:@selector(intro:didScrollWithOffset:)]) {
+        [self.delegate intro:self didScrollWithOffset:offset];
+    }
 }
 
 CGFloat easeOutValue(CGFloat value) {


### PR DESCRIPTION
I'm using this to accomplish some scroll-based fade animations. Here's some sample code:
```
    func intro(introView: EAIntroView!, didScrollWithOffset offset: CGFloat) {
        // Update the opacity of the calloutView

        let currentPageIndex = CGFloat(introView.currentPageIndex)
        
        let alpha: CGFloat
        if offset > currentPageIndex {
            alpha = 1 - (offset - currentPageIndex)
        } else {
            alpha = 1 - (currentPageIndex - offset)
        }
        
        currentCalloutView?.alpha = alpha
    }
```
