### PR TITLE
Use default skipButton and pageControl size when frames are zero

### DIFF
--- a/EAIntroView/EAIntroView.h
+++ b/EAIntroView/EAIntroView.h
@@ -9,6 +9,11 @@
 
 #define EA_EMPTY_PROPERTY 9999.f
 
+#define SKIP_BTN_DEFAULT_WIDTH 100.f
+#define SKIP_BTN_DEFAULT_HEIGHT 40.f
+#define PAGE_CTRL_DEFAULT_HEIGHT 36.f
+
+
 enum EAIntroViewTags {
     kTitleLabelTag = 1,
     kDescLabelTag,

--- a/EAIntroView/EAIntroView.m
+++ b/EAIntroView/EAIntroView.m
@@ -69,7 +69,7 @@
     self.backgroundColor = [UIColor blackColor];
     _scrollingEnabled = YES;
     _titleViewY = 20.f;
-    _pageControlY = 50.f;
+    _pageControlY = 70.f;
     _skipButtonY = EA_EMPTY_PROPERTY;
     _skipButtonSideMargin = 10.f;
     _skipButtonAlignment = EAViewAlignmentRight;
@@ -537,9 +537,13 @@
         [self removeConstraints:self.footerConstraints];
         [self.footerConstraints removeAllObjects];
     }
+
+    CGFloat pageControlHeight = self.pageControl.frame.size.height > 0 ? self.pageControl.frame.size.height : PAGE_CTRL_DEFAULT_HEIGHT;
+    CGFloat skipButtonWidth = self.skipButton.frame.size.width > 0 ? self.skipButton.frame.size.width : SKIP_BTN_DEFAULT_WIDTH;
+    CGFloat skipButtonHeight = self.skipButton.frame.size.height > 0 ? self.skipButton.frame.size.height : SKIP_BTN_DEFAULT_HEIGHT;
     
     NSDictionary *views = @{@"pageControl" : self.pageControl, @"skipButton" : self.skipButton};
-    NSDictionary *metrics = @{@"pageControlBottomPadding" : @(self.pageControlY - self.pageControl.frame.size.height), @"pageControlHeight" : @(self.pageControl.frame.size.height), @"skipButtonBottomPadding" : @(self.skipButtonY - self.skipButton.frame.size.height), @"skipButtonSideMargin" : @(self.skipButtonSideMargin), @"skipButtonWidth" : @(self.skipButton.frame.size.width)};
+    NSDictionary *metrics = @{@"pageControlBottomPadding" : @(self.pageControlY - pageControlHeight), @"pageControlHeight" : @(pageControlHeight), @"skipButtonBottomPadding" : @(self.skipButtonY - skipButtonHeight), @"skipButtonSideMargin" : @(self.skipButtonSideMargin), @"skipButtonWidth" : @(skipButtonWidth)};
     
     [self.footerConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[pageControl]-|" options:NSLayoutFormatAlignAllCenterX metrics:metrics views:views]];
     [self.footerConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[pageControl(pageControlHeight)]-pageControlBottomPadding@250-|" options:NSLayoutFormatAlignAllBottom metrics:metrics views:views]];

--- a/Example/Source/ViewController.m
+++ b/Example/Source/ViewController.m
@@ -59,6 +59,10 @@ static NSString * const sampleDescription4 = @"Nam libero tempore, cum soluta no
     page4.titleIconView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"title4"]];
     
     EAIntroView *intro = [[EAIntroView alloc] initWithFrame:rootView.bounds andPages:@[page1,page2,page3,page4]];
+    intro.skipButtonAlignment = EAViewAlignmentCenter;
+    intro.skipButtonY = 80.f;
+    intro.pageControlY = 42.f;
+
     [intro setDelegate:self];
     
     [intro showInView:rootView animateDuration:0.3];


### PR DESCRIPTION
Fix for #185 
Constraint weren't adequate when zero frames were involved in calculations.